### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: "CI"
+permissions:
+  contents: read
 on: [pull_request]
 jobs:
   build-and-test:


### PR DESCRIPTION
Potential fix for [https://github.com/oskar/dotnet-overview/security/code-scanning/3](https://github.com/oskar/dotnet-overview/security/code-scanning/3)

To fix this issue, we need to explicitly define the `permissions` block in the GitHub Actions workflow. The least privilege necessary for these jobs (`build-and-test` and `lint`) is `contents: read`, as all steps operate only on code and do not need to write, comment, or upload any artifacts. The correct place to add this block is at the workflow root (top-level), so it applies to all jobs. This can be done by adding the following after the `name` (and before `on` or `jobs`):  
```yaml
permissions:
  contents: read
```
No other imports, settings, or method definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
