### PR TITLE
Show Solution path relative or absolute based on flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ are grouped by solution. Supports JSON output for advanced filtering.
 ```bash
 ❯ dotnet tool install -g dotnet-overview
 ❯ dotnet overview
-                    DotNetTools.sln
-┌──────────────────────┬──────────────────┬─────────────────────┐
-│ Project              │ Target framework │ SDK                 │
-├──────────────────────┼──────────────────┼─────────────────────┤
-│ DotNetOpen.Tests     │ net8.0           │ Microsoft.NET.Sdk   │
-│ DotNetOpen           │ net8.0           │ Microsoft.NET.Sdk   │
-│ DotNetOverview.Tests │ net8.0           │ Microsoft.NET.Sdk   │
-│ DotNetOverview       │ net8.0           │ Microsoft.NET.Sdk   │
-└──────────────────────┴──────────────────┴─────────────────────┘
+                        DotNetTools.sln
+┌──────────────────────┬──────────────────┬───────────────────┐
+│ Project              │ Target framework │ SDK               │
+├──────────────────────┼──────────────────┼───────────────────┤
+│ DotNetOpen.Tests     │ net8.0           │ Microsoft.NET.Sdk │
+│ DotNetOpen           │ net8.0           │ Microsoft.NET.Sdk │
+│ DotNetOverview.Tests │ net8.0           │ Microsoft.NET.Sdk │
+│ DotNetOverview       │ net8.0           │ Microsoft.NET.Sdk │
+└──────────────────────┴──────────────────┴───────────────────┘
 Found 4 project(s).
 ```
 

--- a/src/DotNetOverview.Tests/OverviewCommandSolutionTests.cs
+++ b/src/DotNetOverview.Tests/OverviewCommandSolutionTests.cs
@@ -177,6 +177,47 @@ public class OverviewCommandSolutionTests : IDisposable
     }
 
     [Fact]
+    public void Solution_path_is_relative_when_show_paths_flag_set()
+    {
+        // Arrange
+        CreateCsprojFile("ProjectA");
+        CreateSlnxFile("TestSolution", ["ProjectA"]);
+        var console = CreateTestConsole();
+        var command = new OverviewCommand(console);
+        var settings = new OverviewCommand.Settings { Path = _tempDirectory, Json = true, ShowPaths = true };
+
+        // Act
+        command.Execute(null!, settings, CancellationToken.None);
+
+        // Assert
+        var projects = JsonSerializer.Deserialize<Project[]>(console.Output);
+        Assert.NotNull(projects);
+        var project = Assert.Single(projects);
+        Assert.False(Path.IsPathRooted(project.Solution), $"Expected relative path but got: {project.Solution}");
+    }
+
+    [Fact]
+    public void Solution_path_is_absolute_when_show_paths_and_absolute_paths_flags_set()
+    {
+        // Arrange
+        CreateCsprojFile("ProjectA");
+        CreateSlnxFile("TestSolution", ["ProjectA"]);
+        var console = CreateTestConsole();
+        var command = new OverviewCommand(console);
+        var settings = new OverviewCommand.Settings { Path = _tempDirectory, Json = true, ShowPaths = true, AbsolutePaths = true };
+
+        // Act
+        command.Execute(null!, settings, CancellationToken.None);
+
+        // Assert
+        var projects = JsonSerializer.Deserialize<Project[]>(console.Output);
+        Assert.NotNull(projects);
+        var project = Assert.Single(projects);
+        Assert.True(Path.IsPathRooted(project.Solution), $"Expected absolute path but got: {project.Solution}");
+        Assert.StartsWith(_tempDirectory, project.Solution);
+    }
+
+    [Fact]
     public void Groups_projects_by_sln_file()
     {
         // Arrange

--- a/src/DotNetOverview.Tests/OverviewCommandSolutionTests.cs
+++ b/src/DotNetOverview.Tests/OverviewCommandSolutionTests.cs
@@ -69,7 +69,7 @@ public class OverviewCommandSolutionTests : IDisposable
     }
 
     [Fact]
-    public void Json_output_includes_SolutionFileName()
+    public void Json_output_includes_Solution()
     {
         // Arrange
         CreateCsprojFile("InSolution");
@@ -89,10 +89,10 @@ public class OverviewCommandSolutionTests : IDisposable
         Assert.Equal(2, projects.Length);
 
         var inSolution = Assert.Single(projects, p => p.Name == "InSolution");
-        Assert.Equal("TestSolution.slnx", inSolution.SolutionFileName);
+        Assert.Equal("TestSolution.slnx", inSolution.Solution);
 
         var dangling = Assert.Single(projects, p => p.Name == "Dangling");
-        Assert.Null(dangling.SolutionFileName);
+        Assert.Null(dangling.Solution);
     }
 
     [Fact]
@@ -195,7 +195,7 @@ public class OverviewCommandSolutionTests : IDisposable
         var projects = JsonSerializer.Deserialize<Project[]>(console.Output);
         Assert.NotNull(projects);
         Assert.Equal(2, projects.Length);
-        Assert.All(projects, p => Assert.Equal("TestSolution.sln", p.SolutionFileName));
+        Assert.All(projects, p => Assert.Equal("TestSolution.sln", p.Solution));
     }
 
     [Fact]
@@ -218,8 +218,8 @@ public class OverviewCommandSolutionTests : IDisposable
         Assert.NotNull(projects);
         Assert.Equal(2, projects.Length);
         Assert.All(projects, p => Assert.Equal("SharedProject", p.Name));
-        Assert.Contains(projects, p => p.SolutionFileName == "SolutionA.slnx");
-        Assert.Contains(projects, p => p.SolutionFileName == "SolutionB.slnx");
+        Assert.Contains(projects, p => p.Solution == "SolutionA.slnx");
+        Assert.Contains(projects, p => p.Solution == "SolutionB.slnx");
     }
 
     private void CreateCsprojFile(string projectName)

--- a/src/DotNetOverview/OverviewCommand.cs
+++ b/src/DotNetOverview/OverviewCommand.cs
@@ -95,7 +95,7 @@ public sealed class OverviewCommand(IAnsiConsole ansiConsole) : Command<Overview
 
         if (solutionFiles.Length > 0)
         {
-            foreach (var group in projects.GroupBy(p => p.SolutionFileName))
+            foreach (var group in projects.GroupBy(p => p.Solution))
             {
                 if (group.Key is null)
                     continue;
@@ -103,7 +103,7 @@ public sealed class OverviewCommand(IAnsiConsole ansiConsole) : Command<Overview
                 ansiConsole.Write(Utilities.FormatProjects(group.ToList(), settings.ShowPaths, group.Key));
             }
 
-            var dangling = projects.Where(p => p.SolutionFileName is null).ToList();
+            var dangling = projects.Where(p => p.Solution is null).ToList();
             if (dangling.Count > 0)
             {
                 ansiConsole.Write(Utilities.FormatProjects(dangling, settings.ShowPaths,
@@ -143,7 +143,7 @@ public sealed class OverviewCommand(IAnsiConsole ansiConsole) : Command<Overview
             foreach (var projectPath in solution.ProjectPaths.Where(File.Exists))
             {
                 var project = ProjectParser.Parse(projectPath);
-                project.SolutionFileName = solution.Name;
+                project.Solution = solution.Name;
                 projects.Add(project);
             }
         }

--- a/src/DotNetOverview/OverviewCommand.cs
+++ b/src/DotNetOverview/OverviewCommand.cs
@@ -77,12 +77,21 @@ public sealed class OverviewCommand(IAnsiConsole ansiConsole) : Command<Overview
             "Parsing projects...",
             () => CollectProjects(allCsprojFiles, solutionFiles));
 
-        if (!settings.AbsolutePaths)
+        foreach (Project project in projects)
         {
-            // Make paths relative to search path.
-            foreach (Project project in projects)
+            if (!settings.AbsolutePaths)
             {
+                // Adjust path to be relative to search path
                 project.Path = Path.GetRelativePath(searchPath, project.Path);
+            }
+
+            if (project.Solution is not null)
+            {
+                if (!settings.ShowPaths)
+                    project.Solution = Path.GetFileName(project.Solution);
+                else if (!settings.AbsolutePaths)
+                    project.Solution = Path.GetRelativePath(searchPath, project.Solution);
+                // else: ShowPaths + AbsolutePaths → keep the stored absolute path as-is
             }
         }
 
@@ -143,7 +152,7 @@ public sealed class OverviewCommand(IAnsiConsole ansiConsole) : Command<Overview
             foreach (var projectPath in solution.ProjectPaths.Where(File.Exists))
             {
                 var project = ProjectParser.Parse(projectPath);
-                project.Solution = solution.Name;
+                project.Solution = solution.Path;
                 projects.Add(project);
             }
         }

--- a/src/DotNetOverview/Project.cs
+++ b/src/DotNetOverview/Project.cs
@@ -10,5 +10,5 @@ public class Project
     public string? OutputType { get; set; }
     public string? Authors { get; set; }
     public string? Version { get; set; }
-    public string? SolutionFileName { get; set; }
+    public string? Solution { get; set; }
 }


### PR DESCRIPTION
Store the full solution file path on Project.Solution instead of just
the filename. When outputting, format it according to the same flags
used for project paths:

- Default (no flags): filename only, e.g. "MyApp.slnx"
- --show-paths: relative path from the search root
- --show-paths --absolute-paths: full absolute path

Fixes #131