### PR TITLE
Add nuget environment to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on: workflow_dispatch
 jobs:
   publish:
     name: publish
+    environment: nuget
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0


### PR DESCRIPTION
## Summary
- Adds `environment: nuget` to the publish job, enabling GitHub Deployments for a visual history of NuGet publishes

## Test plan
- [x] Create the `nuget` environment in Settings → Environments (if it doesn't exist yet)
- [x] Manually run the publish workflow and verify a deployment entry appears under the repo's Deployments