### PR TITLE
Upgrade to Spectre.Console 0.55 with native ESC support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,9 @@
     <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.0" />
-    <PackageVersion Include="Spectre.Console.Testing" Version="0.53.0" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.55.2" />
+    <PackageVersion Include="Spectre.Console.Testing" Version="0.55.2" />
     <PackageVersion Include="xunit.analyzers" Version="1.27.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/src/DotNetOpen.Tests/OpenSolutionCommandTests.cs
+++ b/src/DotNetOpen.Tests/OpenSolutionCommandTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading;
+using Spectre.Console.Cli;
 using Spectre.Console.Testing;
 using Xunit;
 
@@ -37,7 +38,7 @@ public class OpenSolutionCommandTests : IDisposable
         };
 
         // Act
-        var result = command.Execute(null!, settings, CancellationToken.None);
+        var result = Execute(command, settings);
 
         // Assert
         Assert.Equal(0, result);
@@ -59,7 +60,7 @@ public class OpenSolutionCommandTests : IDisposable
         };
 
         // Act
-        var result = command.Execute(null!, settings, CancellationToken.None);
+        var result = Execute(command, settings);
 
         // Assert
         Assert.Equal(0, result);
@@ -81,7 +82,7 @@ public class OpenSolutionCommandTests : IDisposable
         };
 
         // Act
-        var result = command.Execute(null!, settings, CancellationToken.None);
+        var result = Execute(command, settings);
 
         // Assert
         Assert.Equal(0, result);
@@ -104,7 +105,7 @@ public class OpenSolutionCommandTests : IDisposable
         };
 
         // Act
-        var result = command.Execute(null!, settings, CancellationToken.None);
+        var result = Execute(command, settings);
 
         // Assert
         Assert.Equal(0, result);
@@ -131,7 +132,7 @@ public class OpenSolutionCommandTests : IDisposable
         };
 
         // Act
-        var result = command.Execute(null!, settings, CancellationToken.None);
+        var result = Execute(command, settings);
 
         // Assert
         Assert.Equal(0, result);
@@ -157,7 +158,7 @@ public class OpenSolutionCommandTests : IDisposable
         };
 
         // Act
-        var result = command.Execute(null!, settings, CancellationToken.None);
+        var result = Execute(command, settings);
 
         // Assert
         Assert.Equal(1, result);
@@ -176,7 +177,7 @@ public class OpenSolutionCommandTests : IDisposable
         };
 
         // Act
-        var result = command.Execute(null!, settings, CancellationToken.None);
+        var result = Execute(command, settings);
 
         // Assert
         Assert.Equal(0, result);
@@ -192,4 +193,7 @@ public class OpenSolutionCommandTests : IDisposable
 
         return console;
     }
+
+    private static int Execute(OpenSolutionCommand command, OpenSolutionCommand.Settings settings) =>
+        ((ICommand<OpenSolutionCommand.Settings>)command).ExecuteAsync(null!, settings, CancellationToken.None).GetAwaiter().GetResult();
 }

--- a/src/DotNetOpen/DotNetOpen.csproj
+++ b/src/DotNetOpen/DotNetOpen.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="MinVer" PrivateAssets="All" />
+    <PackageReference Include="Spectre.Console" />
     <PackageReference Include="Spectre.Console.Cli" />
   </ItemGroup>
 

--- a/src/DotNetOpen/OpenSolutionCommand.cs
+++ b/src/DotNetOpen/OpenSolutionCommand.cs
@@ -4,10 +4,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Threading;
-using System.Threading.Tasks;
 using Spectre.Console;
 using Spectre.Console.Cli;
-using Spectre.Console.Rendering;
 
 namespace DotNetOpen;
 
@@ -28,7 +26,7 @@ public sealed class OpenSolutionCommand(IAnsiConsole ansiConsole) : Command<Open
         public bool First { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         if (settings.Version)
         {
@@ -88,16 +86,11 @@ public sealed class OpenSolutionCommand(IAnsiConsole ansiConsole) : Command<Open
             Converter = filePath => Path.GetRelativePath(searchPath, filePath)
         };
         selectionPrompt.AddChoices(files);
+        selectionPrompt.AddCancelResult(() => "");
 
-        string selectedSolution;
-        try
-        {
-            selectedSolution = new EscCancellingConsole(ansiConsole).Prompt(selectionPrompt);
-        }
-        catch (EscapePressedException)
-        {
+        var selectedSolution = ansiConsole.Prompt(selectionPrompt);
+        if (string.IsNullOrEmpty(selectedSolution))
             return 1;
-        }
 
         OpenFile(selectedSolution);
 
@@ -114,37 +107,4 @@ public sealed class OpenSolutionCommand(IAnsiConsole ansiConsole) : Command<Open
         });
     }
 
-    private sealed class EscapePressedException : Exception;
-
-    // Remove when Spectre.Console natively supports ESC cancellation in SelectionPrompt
-    // (tracked in https://github.com/spectreconsole/spectre.console/issues/851)
-    private sealed class EscCancellingConsole(IAnsiConsole inner) : IAnsiConsole
-    {
-        private readonly EscCancellingInput _input = new(inner.Input);
-
-        public Profile Profile => inner.Profile;
-        public IAnsiConsoleCursor Cursor => inner.Cursor;
-        public IAnsiConsoleInput Input => _input;
-        public IExclusivityMode ExclusivityMode => inner.ExclusivityMode;
-        public RenderPipeline Pipeline => inner.Pipeline;
-        public void Clear(bool home) => inner.Clear(home);
-        public void Write(IRenderable renderable) => inner.Write(renderable);
-
-        private sealed class EscCancellingInput(IAnsiConsoleInput inner) : IAnsiConsoleInput
-        {
-            public bool IsKeyAvailable() => inner.IsKeyAvailable();
-
-            public ConsoleKeyInfo? ReadKey(bool intercept)
-            {
-                var key = inner.ReadKey(intercept);
-                return key?.Key == ConsoleKey.Escape ? throw new EscapePressedException() : key;
-            }
-
-            public async Task<ConsoleKeyInfo?> ReadKeyAsync(bool intercept, CancellationToken cancellationToken)
-            {
-                var key = await inner.ReadKeyAsync(intercept, cancellationToken);
-                return key?.Key == ConsoleKey.Escape ? throw new EscapePressedException() : key;
-            }
-        }
-    }
 }

--- a/src/DotNetOverview.Tests/OverviewCommandSolutionTests.cs
+++ b/src/DotNetOverview.Tests/OverviewCommandSolutionTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
+using Spectre.Console.Cli;
 using Spectre.Console.Testing;
 using Xunit;
 
@@ -40,7 +41,7 @@ public class OverviewCommandSolutionTests : IDisposable
         var settings = new OverviewCommand.Settings { Path = _tempDirectory };
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         Assert.Contains("TestSolution", console.Output);
@@ -61,7 +62,7 @@ public class OverviewCommandSolutionTests : IDisposable
         var settings = new OverviewCommand.Settings { Path = _tempDirectory };
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         Assert.Contains("not part of any solution", console.Output);
@@ -82,7 +83,7 @@ public class OverviewCommandSolutionTests : IDisposable
         var settings = new OverviewCommand.Settings { Path = _tempDirectory, Json = true };
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         var projects = JsonSerializer.Deserialize<Project[]>(jsonOutput.ToString());
@@ -107,7 +108,7 @@ public class OverviewCommandSolutionTests : IDisposable
         var settings = new OverviewCommand.Settings { Path = _tempDirectory, Json = true };
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         var projects = JsonSerializer.Deserialize<Project[]>(jsonOutput.ToString());
@@ -128,7 +129,7 @@ public class OverviewCommandSolutionTests : IDisposable
         var settings = new OverviewCommand.Settings { Path = _tempDirectory, Json = true, AbsolutePaths = true };
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         var projects = JsonSerializer.Deserialize<Project[]>(jsonOutput.ToString());
@@ -150,7 +151,7 @@ public class OverviewCommandSolutionTests : IDisposable
         var settings = new OverviewCommand.Settings { Path = _tempDirectory, Json = true };
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         var projects = JsonSerializer.Deserialize<Project[]>(jsonOutput.ToString());
@@ -171,7 +172,7 @@ public class OverviewCommandSolutionTests : IDisposable
         var settings = new OverviewCommand.Settings { Path = _tempDirectory, Json = true, AbsolutePaths = true };
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         var projects = JsonSerializer.Deserialize<Project[]>(jsonOutput.ToString());
@@ -193,7 +194,7 @@ public class OverviewCommandSolutionTests : IDisposable
         var settings = new OverviewCommand.Settings { Path = _tempDirectory, Json = true, ShowPaths = true };
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         var projects = JsonSerializer.Deserialize<Project[]>(jsonOutput.ToString());
@@ -214,7 +215,7 @@ public class OverviewCommandSolutionTests : IDisposable
         var settings = new OverviewCommand.Settings { Path = _tempDirectory, Json = true, ShowPaths = true, AbsolutePaths = true };
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         var projects = JsonSerializer.Deserialize<Project[]>(jsonOutput.ToString());
@@ -238,7 +239,7 @@ public class OverviewCommandSolutionTests : IDisposable
         var settings = new OverviewCommand.Settings { Path = _tempDirectory, Json = true };
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         var projects = JsonSerializer.Deserialize<Project[]>(jsonOutput.ToString());
@@ -261,7 +262,7 @@ public class OverviewCommandSolutionTests : IDisposable
         var settings = new OverviewCommand.Settings { Path = _tempDirectory, Json = true };
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         var projects = JsonSerializer.Deserialize<Project[]>(jsonOutput.ToString());
@@ -320,4 +321,7 @@ public class OverviewCommandSolutionTests : IDisposable
         console.Profile.Width = 1024;
         return console;
     }
+
+    private static int Execute(OverviewCommand command, OverviewCommand.Settings settings) =>
+        ((ICommand<OverviewCommand.Settings>)command).ExecuteAsync(null!, settings, CancellationToken.None).GetAwaiter().GetResult();
 }

--- a/src/DotNetOverview.Tests/OverviewCommandTests.cs
+++ b/src/DotNetOverview.Tests/OverviewCommandTests.cs
@@ -20,7 +20,7 @@ public class OverviewCommandTests
         var settings = new OverviewCommand.Settings { Version = true };
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         Assert.Matches(semVerPattern, console.Output);
@@ -36,7 +36,7 @@ public class OverviewCommandTests
         Assert.False(Directory.Exists(settings.Path), $"Test prerequisite failed: Path '{settings.Path}' should not exist");
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         Assert.Matches(@"^Path does not exist: .*apaththatdoesnotexist\.$", console.Output.Trim());
@@ -52,7 +52,7 @@ public class OverviewCommandTests
         Assert.True(Directory.Exists(settings.Path), $"Test prerequisite failed: Path '{settings.Path}' should exist");
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         Assert.Equal("No csproj files found in path.", console.Output.Trim());
@@ -73,7 +73,7 @@ public class OverviewCommandTests
         Assert.True(Directory.Exists(settings.Path), $"Test prerequisite failed: Path '{settings.Path}' should exist");
 
         // Act
-        command.Execute(null!, settings, CancellationToken.None);
+        Execute(command, settings);
 
         // Assert
         Assert.True(IsJson(jsonOutput.ToString()));
@@ -118,4 +118,7 @@ public class OverviewCommandTests
 
         return console;
     }
+
+    private static int Execute(OverviewCommand command, OverviewCommand.Settings settings) =>
+        ((ICommand<OverviewCommand.Settings>)command).ExecuteAsync(null!, settings, CancellationToken.None).GetAwaiter().GetResult();
 }

--- a/src/DotNetOverview/OverviewCommand.cs
+++ b/src/DotNetOverview/OverviewCommand.cs
@@ -45,7 +45,7 @@ public sealed class OverviewCommand(IAnsiConsole ansiConsole, TextWriter? rawOut
         public bool Json { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         if (settings.Version)
         {


### PR DESCRIPTION
Removes the `EscCancellingConsole` workaround now that [spectreconsole/spectre.console#851](https://github.com/spectreconsole/spectre.console/issues/851) is fixed in 0.55.

## Changes

- **`Directory.Packages.props`**: Add explicit `Spectre.Console` 0.55.2 pin to resolve a runtime binary mismatch — `Spectre.Console.Cli` 0.55.0 ships core 0.55.0 but `Spectre.Console.Testing` 0.55.2 ships core 0.55.2
- **`DotNetOpen.csproj`**: Add explicit `Spectre.Console` reference so the project compiles against 0.55.2
- **Tests**: Update all `command.Execute()` calls to go through `ICommand<T>.ExecuteAsync()` since `Execute()` is now `protected` in Spectre.Console 0.55