### PR TITLE
Code coverage with .NET built-in collector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,20 @@ jobs:
         with:
           dotnet-version: "8.0.x"
       - run: dotnet build
-      - run: dotnet test
+      - run: dotnet test --collect:"Code Coverage" --results-directory ./TestResults
+      - name: Install dotnet-coverage
+        run: dotnet tool install --global dotnet-coverage
+      - name: Convert coverage to Cobertura XML
+        run: dotnet-coverage merge --output TestResults/coverage.cobertura.xml --output-format cobertura "TestResults/**/*.coverage"
+      - name: ReportGenerator
+        uses: danielpalme/ReportGenerator-GitHub-Action@5.5.10
+        with:
+          reports: "TestResults/coverage.cobertura.xml"
+          targetdir: "coveragereport"
+          reporttypes: "MarkdownSummaryGithub"
+          assemblyfilters: "+dotnet-open;+dotnet-overview"
+      - name: Write coverage to job summary
+        run: cat coveragereport/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"
   lint:
     name: "Code linting"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds code coverage reporting to the CI pipeline using the .NET SDK built-in collector.

## What changed

- `dotnet test` now runs with `--collect:"Code Coverage"` and `--results-directory ./TestResults`
- The `dotnet-coverage` global tool is installed and merges the binary `.coverage` output into a single Cobertura XML file
- `danielpalme/ReportGenerator-GitHub-Action` converts the XML into a markdown summary, filtered to `dotnet-open` and `dotnet-overview` assemblies
- The markdown is appended to `$GITHUB_STEP_SUMMARY`, making it visible in the Build and test job summary on each PR
