### PR TITLE
Code coverage with Coverlet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,21 @@ jobs:
         with:
           dotnet-version: "8.0.x"
       - run: dotnet build
-      - run: dotnet test
+      - run: dotnet test --collect:"XPlat Code Coverage" --results-directory ./TestResults
+      - name: Code Coverage Summary
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: "TestResults/**/coverage.cobertura.xml"
+          badge: true
+          fail_below_min: false
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: file
+          thresholds: "60 80"
+      - name: Write coverage to job summary
+        run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"
   lint:
     name: "Code linting"
     runs-on: ubuntu-latest

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />

--- a/src/DotNetOpen.Tests/DotNetOpen.Tests.csproj
+++ b/src/DotNetOpen.Tests/DotNetOpen.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp">

--- a/src/DotNetOverview.Tests/DotNetOverview.Tests.csproj
+++ b/src/DotNetOverview.Tests/DotNetOverview.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp">


### PR DESCRIPTION
Adds code coverage reporting to the CI pipeline using Coverlet.

## What changed

- `coverlet.collector` v10.0.1 added to `Directory.Packages.props` and both test projects (`DotNetOpen.Tests`, `DotNetOverview.Tests`)
- `dotnet test` now runs with `--collect:"XPlat Code Coverage"` and `--results-directory ./TestResults`, producing Cobertura XML directly
- `irongut/CodeCoverageSummary@v1.3.0` parses the XML and generates a markdown summary with line rate, branch rate, health indicators, and a badge
- The markdown is appended to `$GITHUB_STEP_SUMMARY`, making it visible in the Build and test job summary on each PR