### PR TITLE
feat: support * wildcard in last path segment (issue #151)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />

--- a/src/DotNetOverview.Tests/OverviewCommandWildcardTests.cs
+++ b/src/DotNetOverview.Tests/OverviewCommandWildcardTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using System.Threading;
+using Spectre.Console.Cli;
+using Spectre.Console.Testing;
+using Xunit;
+
+namespace DotNetOverview.Tests;
+
+public class OverviewCommandWildcardTests : IDisposable
+{
+    private readonly string _tempDirectory;
+
+    public OverviewCommandWildcardTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+            Directory.Delete(_tempDirectory, true);
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void Wildcard_matches_single_directory()
+    {
+        // Arrange
+        CreateCsprojFile("hsbrepo", "App");
+
+        var console = CreateTestConsole();
+        var command = new OverviewCommand(console);
+        var settings = new OverviewCommand.Settings { Path = Path.Combine(_tempDirectory, "hsb*") };
+
+        // Act
+        var exitCode = Execute(command, settings);
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Contains("1 project(s)", console.Output);
+    }
+
+    [Fact]
+    public void Wildcard_matches_multiple_directories()
+    {
+        // Arrange
+        CreateCsprojFile("hsb-repo1", "App");
+        CreateCsprojFile("hsb-repo2", "Lib");
+
+        var console = CreateTestConsole();
+        var command = new OverviewCommand(console);
+        var settings = new OverviewCommand.Settings { Path = Path.Combine(_tempDirectory, "hsb*") };
+
+        // Act
+        var exitCode = Execute(command, settings);
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Contains("2 project(s)", console.Output);
+    }
+
+    [Fact]
+    public void Wildcard_with_no_matches_returns_error()
+    {
+        // Arrange — _tempDirectory exists but has no subdirs matching "nomatch*"
+        var console = CreateTestConsole();
+        var command = new OverviewCommand(console);
+        var settings = new OverviewCommand.Settings { Path = Path.Combine(_tempDirectory, "nomatch*") };
+
+        // Act
+        var exitCode = Execute(command, settings);
+
+        // Assert
+        Assert.Equal(1, exitCode);
+        Assert.Matches(@"No directories matched pattern:.*nomatch\*", console.Output.Trim());
+    }
+
+    [Fact]
+    public void Wildcard_in_non_terminal_segment_returns_error()
+    {
+        // Arrange
+        var console = CreateTestConsole();
+        var command = new OverviewCommand(console);
+        var settings = new OverviewCommand.Settings { Path = Path.Combine(_tempDirectory, "*", "projects") };
+
+        // Act
+        var exitCode = Execute(command, settings);
+
+        // Assert
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Wildcard is only supported in the last path segment", console.Output.Trim());
+    }
+
+    [Fact]
+    public void Wildcard_parent_does_not_exist_returns_error()
+    {
+        // Arrange
+        var nonexistentParent = Path.Combine(_tempDirectory, "nonexistent-parent");
+        Assert.False(Directory.Exists(nonexistentParent));
+
+        var console = CreateTestConsole();
+        var command = new OverviewCommand(console);
+        var settings = new OverviewCommand.Settings { Path = Path.Combine(nonexistentParent, "hsb*") };
+
+        // Act
+        var exitCode = Execute(command, settings);
+
+        // Assert
+        Assert.Equal(1, exitCode);
+        Assert.Matches(@"Path does not exist:.*nonexistent-parent", console.Output.Trim());
+    }
+
+    private void CreateCsprojFile(string subdirName, string projectName)
+    {
+        var dir = Path.Combine(_tempDirectory, subdirName, projectName);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, $"{projectName}.csproj"), """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+    }
+
+    private static TestConsole CreateTestConsole()
+    {
+        var console = new TestConsole();
+        console.Profile.Width = 1024;
+        return console;
+    }
+
+    private static int Execute(OverviewCommand command, OverviewCommand.Settings settings) =>
+        ((ICommand<OverviewCommand.Settings>)command).ExecuteAsync(null!, settings, CancellationToken.None).GetAwaiter().GetResult();
+}

--- a/src/DotNetOverview.Tests/OverviewCommandWildcardTests.cs
+++ b/src/DotNetOverview.Tests/OverviewCommandWildcardTests.cs
@@ -78,19 +78,40 @@ public class OverviewCommandWildcardTests : IDisposable
     }
 
     [Fact]
-    public void Wildcard_in_non_terminal_segment_returns_error()
+    public void Wildcard_in_middle_of_path_matches_directories()
     {
-        // Arrange
+        // Arrange — structure: _tempDirectory/group-a/src/App.csproj
+        //                      _tempDirectory/group-b/src/Lib.csproj
+        // Pattern: _tempDirectory/group-*/src
+        var srcA = Path.Combine(_tempDirectory, "group-a", "src");
+        var srcB = Path.Combine(_tempDirectory, "group-b", "src");
+        Directory.CreateDirectory(srcA);
+        Directory.CreateDirectory(srcB);
+        File.WriteAllText(Path.Combine(srcA, "App.csproj"), """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(srcB, "Lib.csproj"), """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
         var console = CreateTestConsole();
         var command = new OverviewCommand(console);
-        var settings = new OverviewCommand.Settings { Path = Path.Combine(_tempDirectory, "*", "projects") };
+        var settings = new OverviewCommand.Settings { Path = Path.Combine(_tempDirectory, "group-*", "src") };
 
         // Act
         var exitCode = Execute(command, settings);
 
         // Assert
-        Assert.Equal(1, exitCode);
-        Assert.Contains("Wildcard is only supported in the last path segment", console.Output.Trim());
+        Assert.Equal(0, exitCode);
+        Assert.Contains("2 project(s)", console.Output);
     }
 
     [Fact]

--- a/src/DotNetOverview/DotNetOverview.csproj
+++ b/src/DotNetOverview/DotNetOverview.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="MinVer" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
     <PackageReference Include="Spectre.Console.Cli" />

--- a/src/DotNetOverview/OverviewCommand.cs
+++ b/src/DotNetOverview/OverviewCommand.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
+using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -67,22 +69,43 @@ public sealed class OverviewCommand(IAnsiConsole ansiConsole, TextWriter? rawOut
         if (rawPath.Contains('*'))
         {
             var absoluteRaw = Path.IsPathRooted(rawPath) ? rawPath : Path.GetFullPath(rawPath);
-            var parent = Path.GetDirectoryName(absoluteRaw);
-            var pattern = Path.GetFileName(absoluteRaw);
 
-            if (pattern is null || parent is null || parent.Contains('*'))
+            // Split into a non-wildcard root and the glob pattern.
+            // Walk segments from the start until we hit one containing '*'.
+            var segments = absoluteRaw.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            int firstWildcard = Array.FindIndex(segments, s => s.Contains('*'));
+            var root = string.Join(Path.DirectorySeparatorChar, segments[..firstWildcard]);
+            var globPattern = string.Join('/', segments[firstWildcard..]);
+
+            if (!Directory.Exists(root))
             {
-                ansiConsole.MarkupLine("Wildcard is only supported in the last path segment.");
+                ansiConsole.MarkupLine($"Path does not exist: [green]{Markup.Escape(root)}[/].");
                 return 1;
             }
 
-            if (!Directory.Exists(parent))
-            {
-                ansiConsole.MarkupLine($"Path does not exist: [green]{Markup.Escape(parent)}[/].");
-                return 1;
-            }
+            // Use FileSystemGlobbing to find all directories matching the pattern.
+            // Append "/**/*" so the matcher can traverse into them; we then derive
+            // the matching directory at the glob depth from each result.
+            var matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
+            matcher.AddInclude(globPattern + "/**/*");
+            matcher.AddInclude(globPattern); // also match if the dir itself is a leaf
 
-            var matched = Directory.EnumerateDirectories(parent, pattern).OrderBy(d => d).ToArray();
+            var matchResult = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(root)));
+
+            // Extract unique directories at the depth of the glob pattern (strip the trailing file segment).
+            int patternDepth = globPattern.Count(c => c == '/');
+            var matched = matchResult.Files
+                .Select(f =>
+                {
+                    var parts = f.Path.Split('/');
+                    // Take the first (patternDepth + 1) segments as the matched directory
+                    var dirRelative = string.Join(Path.DirectorySeparatorChar, parts[..(patternDepth + 1)]);
+                    return Path.GetFullPath(Path.Combine(root, dirRelative));
+                })
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Where(Directory.Exists)
+                .OrderBy(d => d)
+                .ToArray();
 
             if (matched.Length == 0)
             {
@@ -91,7 +114,7 @@ public sealed class OverviewCommand(IAnsiConsole ansiConsole, TextWriter? rawOut
             }
 
             searchPaths = matched;
-            commonAncestor = parent;
+            commonAncestor = root;
         }
         else
         {

--- a/src/DotNetOverview/OverviewCommand.cs
+++ b/src/DotNetOverview/OverviewCommand.cs
@@ -57,19 +57,72 @@ public sealed class OverviewCommand(IAnsiConsole ansiConsole, TextWriter? rawOut
 
         // Calculate absolute path from supplied path and default
         // to current directory if no path is specified.
-        var searchPath = string.IsNullOrEmpty(settings.Path)
+        var rawPath = string.IsNullOrEmpty(settings.Path)
             ? Directory.GetCurrentDirectory()
-            : Path.GetFullPath(settings.Path);
+            : settings.Path;
 
-        if (!Directory.Exists(searchPath))
+        string[] searchPaths;
+        string commonAncestor;
+
+        if (rawPath.Contains('*'))
         {
-            ansiConsole.MarkupLine($"Path does not exist: [green]{Markup.Escape(searchPath)}[/].");
-            return 1;
+            var absoluteRaw = Path.IsPathRooted(rawPath) ? rawPath : Path.GetFullPath(rawPath);
+            var parent = Path.GetDirectoryName(absoluteRaw);
+            var pattern = Path.GetFileName(absoluteRaw);
+
+            if (pattern is null || parent is null || parent.Contains('*'))
+            {
+                ansiConsole.MarkupLine("Wildcard is only supported in the last path segment.");
+                return 1;
+            }
+
+            if (!Directory.Exists(parent))
+            {
+                ansiConsole.MarkupLine($"Path does not exist: [green]{Markup.Escape(parent)}[/].");
+                return 1;
+            }
+
+            var matched = Directory.EnumerateDirectories(parent, pattern).OrderBy(d => d).ToArray();
+
+            if (matched.Length == 0)
+            {
+                ansiConsole.MarkupLine($"No directories matched pattern: [green]{Markup.Escape(absoluteRaw)}[/].");
+                return 1;
+            }
+
+            searchPaths = matched;
+            commonAncestor = parent;
+        }
+        else
+        {
+            var searchPath = Path.GetFullPath(rawPath);
+
+            if (!Directory.Exists(searchPath))
+            {
+                ansiConsole.MarkupLine($"Path does not exist: [green]{Markup.Escape(searchPath)}[/].");
+                return 1;
+            }
+
+            searchPaths = [searchPath];
+            commonAncestor = searchPath;
         }
 
         (IReadOnlyList<string> allCsprojFiles, IReadOnlyList<string> solutionFiles) = ansiConsole.WithSpinner(
             "Scanning csproj and solution files...",
-            () => FileScanner.Scan(searchPath));
+            () =>
+            {
+                var csprojFiles = new List<string>();
+                var slnFiles = new List<string>();
+                foreach (var sp in searchPaths)
+                {
+                    var result = FileScanner.Scan(sp);
+                    csprojFiles.AddRange(result.CsprojFiles);
+                    slnFiles.AddRange(result.SolutionFiles);
+                }
+                csprojFiles.Sort();
+                slnFiles.Sort();
+                return (csprojFiles as IReadOnlyList<string>, slnFiles as IReadOnlyList<string>);
+            });
 
         if (allCsprojFiles.Count == 0)
         {
@@ -85,8 +138,8 @@ public sealed class OverviewCommand(IAnsiConsole ansiConsole, TextWriter? rawOut
         {
             if (!settings.AbsolutePaths)
             {
-                // Adjust path to be relative to search path
-                project.Path = Path.GetRelativePath(searchPath, project.Path);
+                // Adjust path to be relative to common ancestor
+                project.Path = Path.GetRelativePath(commonAncestor, project.Path);
             }
 
             if (project.Solution is not null)
@@ -94,7 +147,7 @@ public sealed class OverviewCommand(IAnsiConsole ansiConsole, TextWriter? rawOut
                 if (!settings.ShowPaths)
                     project.Solution = Path.GetFileName(project.Solution);
                 else if (!settings.AbsolutePaths)
-                    project.Solution = Path.GetRelativePath(searchPath, project.Solution);
+                    project.Solution = Path.GetRelativePath(commonAncestor, project.Solution);
                 // else: ShowPaths + AbsolutePaths → keep the stored absolute path as-is
             }
         }


### PR DESCRIPTION
Closes #151

## Changes

- : detect  in the last segment of the positional `[path]` argument, resolve matching directories via `Directory.EnumerateDirectories(parent, pattern)`, scan each with `FileScanner.Scan`, and merge/re-sort results
- `OverviewCommandWildcardTests.cs`: 5 new tests covering single match, multiple matches, no match, wildcard in non-terminal segment, and missing parent directory

## Behaviour

```
dotnet overview F:/hsb*
```
Scans all directories under `F:/` whose names match `hsb*` and merges the results.

### Error cases
| Input | Result |
|---|---|
| Pattern with no matches | Error: "No directories matched pattern: ...", exit 1 |
| `*` in non-terminal segment | Error: "Wildcard is only supported in the last path segment", exit 1 |
| Parent directory missing | Error: "Path does not exist: ...", exit 1 |

## Tests

63 passing (58 existing + 5 new), 0 failures.