### PR TITLE
Fix crash when paths or project names contain square brackets

### DIFF
--- a/src/DotNetOpen.Tests/OpenSolutionCommandTests.cs
+++ b/src/DotNetOpen.Tests/OpenSolutionCommandTests.cs
@@ -27,6 +27,27 @@ public class OpenSolutionCommandTests : IDisposable
     }
 
     [Fact]
+    public void Does_not_crash_when_solution_name_contains_square_brackets()
+    {
+        // Arrange - solution name with square brackets that would otherwise be parsed as Spectre markup
+        const string fileName = "[deprecated]solution.sln";
+        File.WriteAllText(Path.Combine(_tempDirectory, fileName), "");
+        File.WriteAllText(Path.Combine(_tempDirectory, "Other.sln"), "");
+        var console = CreateTestConsole();
+        var command = new OpenSolutionCommand(console);
+        var settings = new OpenSolutionCommand.Settings
+        {
+            Path = _tempDirectory,
+            First = true
+        };
+
+        // Act & Assert - should not throw
+        var result = Execute(command, settings);
+        Assert.Equal(0, result);
+        Assert.Contains(fileName, console.Output);
+    }
+
+    [Fact]
     public void Execute_returns_0_when_no_solution_found()
     {
         // Arrange

--- a/src/DotNetOpen/OpenSolutionCommand.cs
+++ b/src/DotNetOpen/OpenSolutionCommand.cs
@@ -44,7 +44,7 @@ public sealed class OpenSolutionCommand(IAnsiConsole ansiConsole) : Command<Open
 
         if (!Directory.Exists(searchPath))
         {
-            ansiConsole.MarkupLine($"Path does not exist: [green]{searchPath}[/].");
+            ansiConsole.MarkupLine($"Path does not exist: [green]{Markup.Escape(searchPath)}[/].");
             return 1;
         }
 
@@ -70,7 +70,7 @@ public sealed class OpenSolutionCommand(IAnsiConsole ansiConsole) : Command<Open
             return 0;
         }
 
-        ansiConsole.MarkupLine($"Found [green]{files.Length}[/] solutions in [green]{searchPath}[/].");
+        ansiConsole.MarkupLine($"Found [green]{files.Length}[/] solutions in [green]{Markup.Escape(searchPath)}[/].");
 
         if (settings.First)
         {
@@ -83,7 +83,7 @@ public sealed class OpenSolutionCommand(IAnsiConsole ansiConsole) : Command<Open
             Title = "Select which to open:",
             PageSize = 15,
             SearchEnabled = true,
-            Converter = filePath => Path.GetRelativePath(searchPath, filePath)
+            Converter = filePath => Markup.Escape(Path.GetRelativePath(searchPath, filePath))
         };
         selectionPrompt.AddChoices(files);
         selectionPrompt.AddCancelResult(() => "");
@@ -99,7 +99,7 @@ public sealed class OpenSolutionCommand(IAnsiConsole ansiConsole) : Command<Open
 
     private void OpenFile(string filePath)
     {
-        ansiConsole.MarkupLine($"Opening [green]{filePath}[/].");
+        ansiConsole.MarkupLine($"Opening [green]{Markup.Escape(filePath)}[/].");
         Process.Start(new ProcessStartInfo
         {
             FileName = filePath,

--- a/src/DotNetOverview.Tests/OverviewCommandSolutionTests.cs
+++ b/src/DotNetOverview.Tests/OverviewCommandSolutionTests.cs
@@ -249,6 +249,23 @@ public class OverviewCommandSolutionTests : IDisposable
     }
 
     [Fact]
+    public void Does_not_crash_when_project_name_contains_square_brackets()
+    {
+        // Arrange - project name with square brackets that would otherwise be parsed as Spectre markup
+        const string projectName = "[deprecated]project";
+        CreateCsprojFile(projectName);
+
+        var console = CreateTestConsole();
+        var command = new OverviewCommand(console);
+        var settings = new OverviewCommand.Settings { Path = _tempDirectory };
+
+        // Act & Assert - should not throw
+        var exitCode = Execute(command, settings);
+        Assert.Equal(0, exitCode);
+        Assert.Contains(projectName, console.Output);
+    }
+
+    [Fact]
     public void Project_in_multiple_solutions_appears_multiple_times()
     {
         // Arrange - one project referenced by two solutions

--- a/src/DotNetOverview/OverviewCommand.cs
+++ b/src/DotNetOverview/OverviewCommand.cs
@@ -63,7 +63,7 @@ public sealed class OverviewCommand(IAnsiConsole ansiConsole, TextWriter? rawOut
 
         if (!Directory.Exists(searchPath))
         {
-            ansiConsole.MarkupLine($"Path does not exist: [green]{searchPath}[/].");
+            ansiConsole.MarkupLine($"Path does not exist: [green]{Markup.Escape(searchPath)}[/].");
             return 1;
         }
 

--- a/src/DotNetOverview/Utilities.cs
+++ b/src/DotNetOverview/Utilities.cs
@@ -47,9 +47,9 @@ public static class Utilities
         foreach (var project in projects)
         {
             table.AddRow(
-              showPath ? project.Path : project.Name,
-              project.TargetFramework ?? "",
-              project.Sdk ?? ""
+              Markup.Escape(showPath ? project.Path : project.Name),
+              Markup.Escape(project.TargetFramework ?? ""),
+              Markup.Escape(project.Sdk ?? "")
             );
         }
 


### PR DESCRIPTION
Spectre.Console interprets strings passed to markup APIs as markup, so
names like [deprecated]project.csproj or [deprecated]solution.sln caused
exceptions when the brackets were parsed as color tags.

Fix by applying Markup.Escape() to all user-supplied strings before they
are interpolated into markup strings. This covers:
- Table rows in dotnet-overview (project name, target framework, SDK)
- MarkupLine calls in dotnet-overview and dotnet-open (path messages)
- SelectionPrompt converter in dotnet-open (solution list display)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes #152